### PR TITLE
pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ An oEmbed client written in Ruby, letting you easily get embeddable HTML represe
 
 You get embedable resources via an OEmbed::Provider. This gem comes with many Providers built right in, to make your life easy.
 
-    resource = OEmbed::Providers::YouTube.get("http://www.youtube.com/watch?v=2BYXBC8WQ5k")
+    resource = OEmbed::Providers::Youtube.get("http://www.youtube.com/watch?v=2BYXBC8WQ5k")
     resource.video? #=> true
     resource.thumbnail_url #=> "http://i3.ytimg.com/vi/2BYXBC8WQ5k/hqdefault.jpg"
     resource.html #=> '<object width="425" height="344"><param name="movie" value="http://www.youtube.com/v/2BYXBC8WQ5k?fs=1"></param><param name="allowFullScreen" value="true"></param><param name="allowscriptaccess" value="always"></param><embed src="http://www.youtube.com/v/2BYXBC8WQ5k?fs=1" type="application/x-shockwave-flash" width="425" height="344" allowscriptaccess="always" allowfullscreen="true"></embed></object>'
 
-If you'd like to use a provider that isn't included in the library, it's easy to add one. Just provide the oEmbed API endpoint and URL scheme(s). 
+If you'd like to use a provider that isn't included in the library, it's easy to add one. Just provide the oEmbed API endpoint and URL scheme(s).
 
     my_provider = OEmbed::Provider.new("http://my.cool-service.com/api/oembed_endpoint.{format}"
     my_provider << "http://*.cool-service.com/image/*"
@@ -25,10 +25,10 @@ If you'd like to use a provider that isn't included in the library, it's easy to
 
 To use multiple Providers at once, simply register them.
 
-    OEmbed::Providers.register(OEmbed::Providers::YouTube, my_provider)
+    OEmbed::Providers.register(OEmbed::Providers::Youtube, my_provider)
     resource = OEmbed::Providers.get("http://www.youtube.com/watch?v=2BYXBC8WQ5k") #=> OEmbed::Response
     resource.type #=> "video"
-    resource.provider.name #=> "YouTube"
+    resource.provider.name #=> "Youtube"
 
 Last but not least, ruby-oembed supports both [oohEmbed][oohembed] and [Embedly][embedly]. These services are provider aggregators. Each supports a wide array of websites ranging from [Amazon.com](http://www.amazon.com) to [xkcd](http://www.xkcd.com).
 


### PR DESCRIPTION
Corrected the provider syntax for youtube (from YouTube to Youtube) in README.rb - it was failing for me until i changed the case.
