### PR TITLE
create gemset, if it does not exist

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm default@oembed
+rvm --create use default@oembed


### PR DESCRIPTION
to avoid this error

```
Gemset 'oembed' does not exist, rvm gemset create 'oembed' first.
Gemset doesn't exist, proceeding with default gemset
```
