### PR TITLE
make sure URLs are escaped

### DIFF
--- a/lib/oembed/provider.rb
+++ b/lib/oembed/provider.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 module OEmbed
   # An OEmbed::Provider has information about an individual oEmbed enpoint.
   class Provider
@@ -94,7 +95,7 @@ module OEmbed
     def build(url, query = {})
       raise OEmbed::NotFound, url unless include?(url)
 
-      query = query.merge({:url=>url})
+      query = query.merge({:url => ::CGI.escape(url)})
       # TODO: move this code exclusively into the get method, once build is private.
       this_format = (query[:format] ||= @format.to_s).to_s
       

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -219,13 +219,13 @@ describe OEmbed::Provider do
       uri.host.should == "www.flickr.com"
       uri.path.should == "/services/oembed/"
       uri.query.include?("format=#{@flickr.format}").should be_true
-      uri.query.include?("url=http://flickr.com/photos/bees/2362225867/").should be_true
+      uri.query.include?("url=#{CGI.escape 'http://flickr.com/photos/bees/2362225867/'}").should be_true
 
       uri = @qik.send(:build, example_url(:qik))
       uri.host.should == "qik.com"
       uri.path.should == "/api/oembed.xml"
       uri.query.include?("format=#{@qik.format}").should be_false
-      uri.query.should == "url=http://qik.com/video/49565"
+      uri.query.should == "url=#{CGI.escape 'http://qik.com/video/49565'}"
     end
 
     it "should accept parameters" do


### PR DESCRIPTION
Talking to Embed.ly was not working, because URLs were passed on the query string in the clear. To fix, you need to use CGI.escape to encode the URLs on the query string.
