### PR TITLE
Allow query params in oEmbed API endpoint

### DIFF
--- a/lib/oembed/provider.rb
+++ b/lib/oembed/provider.rb
@@ -105,7 +105,8 @@ module OEmbed
         query.delete(:format)
       end
 
-      query = "?" + query.inject("") do |memo, (key, value)|
+      base = endpoint.include?('?') ? '&' : '?'
+      query = base + query.inject("") do |memo, (key, value)|
         "#{key}=#{value}&#{memo}"
       end.chop
 

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -164,6 +164,13 @@ describe OEmbed::Provider do
     provier.include?("gopher://foo.com/1").should be_false
   end
 
+  it 'should allow a query parameters in URI schema' do
+    provider = OEmbed::Provider.new('http://www.youtube.com/oembed?scheme=https')
+    provider << 'http://*.youtube.com/*'
+    provider.include?('http://youtube.com/watch?v=M3r2XDceM6A').should be_true
+    provider.build('http://youtube.com/watch?v=M3r2XDceM6A').to_s.should == 'http://www.youtube.com/oembed?scheme=https&format=json&url=http://youtube.com/watch?v=M3r2XDceM6A'
+  end
+
   it "should by default use OEmbed::Formatter.default" do
     @flickr.format.should == @default
   end


### PR DESCRIPTION
Useful for registering 'http://www.youtube.com/oembed?scheme=https' as
an OEmbed::Provider (extension to embed content via https).
