### PR TITLE
Add HTTPS provider endpoints via :sub_type

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -45,9 +45,12 @@ module OEmbed
       # The including_sub_type parameter should be one of the following values:
       # * :aggregators: also register provider aggregator endpoints, like Embedly
       def register_all(*including_sub_type)
-        register(*@@to_register[""])
-        including_sub_type.each do |sub_type|
-          register(*@@to_register[sub_type.to_s])
+        if including_sub_type.any?
+          including_sub_type.each do |sub_type|
+            register(*@@to_register[sub_type.to_s])
+          end
+        else
+          register(*@@to_register[""])
         end
       end
 

--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -134,8 +134,6 @@ module OEmbed
     #     OEmbed::Providers::Youtube.endpoint += "?iframe=1"
     # * To get the flash/object embed code
     #     OEmbed::Providers::Youtube.endpoint += "?iframe=0"
-    # * To require https embed code
-    #     OEmbed::Providers::Youtube.endpoint += "?scheme=https"
     Youtube = OEmbed::Provider.new("http://www.youtube.com/oembed")
     Youtube << "http://*.youtube.com/*"
     Youtube << "https://*.youtube.com/*"
@@ -143,11 +141,22 @@ module OEmbed
     Youtube << "https://*.youtu.be/*"
     add_official_provider(Youtube)
 
+    YoutubeHttps = OEmbed::Provider.new("http://www.youtube.com/oembed?scheme=https")
+    YoutubeHttps << "http://*.youtube.com/*"
+    YoutubeHttps << "https://*.youtube.com/*"
+    YoutubeHttps << "http://*.youtu.be/*"
+    YoutubeHttps << "https://*.youtu.be/*"
+    add_official_provider(YoutubeHttps, :https)
+
     # Provider for flickr.com
     # http://developer.yahoo.com/blogs/ydn/posts/2008/05/oembed_embeddin/
     Flickr = OEmbed::Provider.new("http://www.flickr.com/services/oembed/")
     Flickr << "http://*.flickr.com/*"
     add_official_provider(Flickr)
+
+    FlickrHttps = OEmbed::Provider.new("https://www.flickr.com/services/oembed/")
+    FlickrHttps << "http://*.flickr.com/*"
+    add_official_provider(FlickrHttps, :https)
 
     # Provider for viddler.com
     # http://developers.viddler.com/documentation/services/oembed/
@@ -178,6 +187,11 @@ module OEmbed
     Vimeo << "http://*.vimeo.com/*"
     Vimeo << "https://*.vimeo.com/*"
     add_official_provider(Vimeo)
+
+    VimeoHttps = OEmbed::Provider.new("https://vimeo.com/api/oembed.{format}")
+    VimeoHttps << "http://*.vimeo.com/*"
+    VimeoHttps << "https://*.vimeo.com/*"
+    add_official_provider(VimeoHttps, :https)
     
     # Provider for instagram.com
     # http://instagr.am/developer/embedding/
@@ -192,6 +206,11 @@ module OEmbed
     Slideshare << "http://www.slideshare.net/*/*"
     Slideshare << "http://www.slideshare.net/mobile/*/*"
     add_official_provider(Slideshare)
+
+    SlideshareHttps = OEmbed::Provider.new("https://www.slideshare.net/api/oembed/2")
+    SlideshareHttps << "http://www.slideshare.net/*/*"
+    SlideshareHttps << "http://www.slideshare.net/mobile/*/*"
+    add_official_provider(SlideshareHttps, :https)
     
     # Provider for yfrog
     # http://code.google.com/p/imageshackapi/wiki/OEMBEDSupport

--- a/spec/providers_spec.rb
+++ b/spec/providers_spec.rb
@@ -253,6 +253,34 @@ describe OEmbed::Providers do
           provider.should be_a(OEmbed::Provider)
         end
       end
+
+      it "should only register either default provider or sub_type providers but not both" do
+        defined?(OEmbed::Providers::Fake).should_not be
+
+        class OEmbed::Providers
+          Default = OEmbed::Provider.new("http://default.com/oembed/")
+          Default << "http://default.com/*"
+          add_official_provider(Default)
+
+          SubType = OEmbed::Provider.new("http://subtype.net/oembed/")
+          SubType << "http://subtype.net/*"
+          add_official_provider(SubType, :subtype)
+        end
+
+        OEmbed::Providers.register_all
+        ["http://subtype.net/123"].each do |url|
+          provider = OEmbed::Providers.find(url)
+          provider.should_not be_a(OEmbed::Provider)
+        end
+
+        OEmbed::Providers.unregister_all
+
+        OEmbed::Providers.register_all(:subtype)
+        ["http://default.com/123"].each do |url|
+          provider = OEmbed::Providers.find(url)
+          provider.should_not be_a(OEmbed::Provider)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds several well-known HTTPS provider endpoints (See https://github.com/judofyr/ruby-oembed/issues/28).  Since these provider endpoints potentially collide with HTTP provider endpoints- `OEmbed::Providers.register_all` was modified to allow the user to control their preference. For example, registering `:https` provider endpoints first favors these over default provider endpoints:

```
OEmbed::Providers.register_all(:https)
OEmbed::Providers.register_all
```
