### PR TITLE
Allow soundcloud https oembeds

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -253,6 +253,7 @@ module OEmbed
     # http://developers.soundcloud.com/docs/oembed
     SoundCloud = OEmbed::Provider.new("http://soundcloud.com/oembed", :json)
     SoundCloud << "http://*.soundcloud.com/*"
+    SoundCloud << "https://*.soundcloud.com/*"
     add_official_provider(SoundCloud)
 
     # Provider for skitch.com


### PR DESCRIPTION
soundcloud is using https a lot in their new site and their
oembed endpoint supports it, commit adds support for that.
