### PR TITLE
Allow specifying HTTP timeout to Provider.get

### DIFF
--- a/lib/oembed/provider.rb
+++ b/lib/oembed/provider.rb
@@ -78,6 +78,7 @@ module OEmbed
     # The query parameter should be a Hash of values which will be
     # sent as query parameters in this request to the Provider endpoint. The
     # following special cases apply to the query Hash:
+    # :timeout:: specifies the timeout (in seconds) for the http request.
     # :format:: overrides this Provider's default request format.
     # :url:: will be ignored, replaced by the url param.
     def get(url, query = {})
@@ -96,6 +97,8 @@ module OEmbed
       raise OEmbed::NotFound, url unless include?(url)
 
       query = query.merge({:url => ::CGI.escape(url)})
+      query.delete(:timeout)
+
       # TODO: move this code exclusively into the get method, once build is private.
       this_format = (query[:format] ||= @format.to_s).to_s
       
@@ -130,6 +133,7 @@ module OEmbed
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = uri.scheme == 'https'
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        http.read_timeout = http.open_timeout = query[:timeout] if query[:timeout]
         
         %w{scheme userinfo host port registry}.each { |method| uri.send("#{method}=", nil) }
         res = http.request(Net::HTTP::Get.new(uri.to_s))

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 require 'vcr'
 
 VCR.config do |c|
-  c.default_cassette_options = { :record => :new_episodes }
+  c.default_cassette_options = { :record => :none }
   c.cassette_library_dir = 'spec/cassettes'
   c.stub_with :fakeweb
 end
@@ -256,6 +256,15 @@ describe OEmbed::Provider do
       uri.query.include?("scheme=https").should be_true
       uri.query.include?("url=#{CGI.escape url}").should be_true
     end
+
+    it "should not include the :timeout parameter in the query string" do
+      uri = @flickr.send(:build, example_url(:flickr),
+        :timeout => 5,
+        :another => "test")
+
+      uri.query.include?("timeout=5").should be_false
+      uri.query.include?("another=test").should be_true
+    end
   end
 
   describe "#raw" do
@@ -363,6 +372,12 @@ describe OEmbed::Provider do
         with(example_url(:viddler), :format=>:json).
         and_return(valid_response(:json))
       @viddler.get(example_url(:viddler))
+    end
+
+    it "handles the :timeout option" do
+      Net::HTTP.any_instance.should_receive(:open_timeout=).with(5)
+      Net::HTTP.any_instance.should_receive(:read_timeout=).with(5)
+      @flickr.get(example_url(:flickr), :timeout => 5)
     end
   end
 end


### PR DESCRIPTION
Passing `:timeout => 5` to `OEmbed::Provider.get` configures the `read_timeout` and `open_timeout` properties of the raw Net::HTTP object appropriately.
