### PR TITLE
Update slideshare url schema

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -227,8 +227,10 @@ module OEmbed
     # Provider for slideshare.net
     # http://www.slideshare.net/developers/oembed
     Slideshare = OEmbed::Provider.new("https://www.slideshare.net/api/oembed/2")
-    Slideshare << "http://www.slideshare.net/*/*"
-    Slideshare << "http://www.slideshare.net/mobile/*/*"
+    Slideshare << 'http://*.slideshare.net/*/*'
+    Slideshare << 'https://*.slideshare.net/*/*'
+    Slideshare << 'http://*.slideshare.net/mobile/*/*'
+    Slideshare << 'https://*.slideshare.net/mobile/*/*'
     add_official_provider(Slideshare)
 
     # Provider for yfrog


### PR DESCRIPTION
Hi all,
i've changed the slideshare.net urls to match the new schema.
Slideshare doesn't use the _www_ subdomain anymore, instead they are using language subdomains. And of course you can use https urls (redirects to http) too.

For example: https://de.slideshare.net/gabriele.lana/the-magic-of-elixir

There are no specs for provider specific stuff, correct? How do you think about it?

Cheers!
Axel - dino115