### PR TITLE
Updates to Twitter oEmbed Endpoint

### DIFF
--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -183,7 +183,7 @@ module OEmbed
 
     # Provider for twitter.com
     # https://dev.twitter.com/rest/reference/get/statuses/oembed
-    Twitter = OEmbed::Provider.new("https://publish.twitter.com/oembed")
+    Twitter = OEmbed::Provider.new("https://publish.twitter.com/oembed", :json)
     Twitter << "https://*.twitter.com/*/status/*"
     add_official_provider(Twitter)
 

--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -183,7 +183,7 @@ module OEmbed
 
     # Provider for twitter.com
     # https://dev.twitter.com/rest/reference/get/statuses/oembed
-    Twitter = OEmbed::Provider.new("https://api.twitter.com/1/statuses/oembed.{format}")
+    Twitter = OEmbed::Provider.new("https://publish.twitter.com/oembed")
     Twitter << "https://*.twitter.com/*/status/*"
     add_official_provider(Twitter)
 


### PR DESCRIPTION
Twitter recently changed their oEmbed endpoint from `https://api.twitter.com/1/statuses/oembed.json` to `https://publish.twitter.com/oembed`. The old URL currently works, but I'm not sure for how long.

I found out about this because they also discontinued support for XML responses on May 1, and I happened to be passing `:xml` as the second parameter to `OEmbed::Providers.get()`, for some reason.

This pull request uses the new oEmbed endpoint URL for Twitter and sets `:json` as the default format. If folks override this with `:xml`, they'll see 410 Gone exception messages.

References:

* https://dev.twitter.com/rest/reference/get/statuses/oembed
* https://twittercommunity.com/t/deprecation-of-xml-response-type-for-single-tweet-oembed/62013
* https://www.apichangelog.com/changes/1df28f75-4cf5-4346-a57a-9e8083174bee