### PR TITLE
replace relative protocol for discoverable endpoint

### DIFF
--- a/lib/oembed/provider_discovery.rb
+++ b/lib/oembed/provider_discovery.rb
@@ -50,7 +50,7 @@ module OEmbed
       end
 
       begin
-        provider_endpoint = URI.parse(provider_endpoint)
+        provider_endpoint = URI.parse(provider_endpoint.sub(%r{^//}, 'http://'))
         provider_endpoint.query = nil
         provider_endpoint = provider_endpoint.to_s
       rescue URI::Error

--- a/lib/oembed/provider_discovery.rb
+++ b/lib/oembed/provider_discovery.rb
@@ -50,7 +50,12 @@ module OEmbed
       end
 
       begin
-        provider_endpoint = URI.parse(provider_endpoint.sub(%r{^//}, 'http://'))
+        provider_endpoint = URI.parse(provider_endpoint)
+        # merge the original resource uri with endpoint url
+        # to set correct protocol in case discoverable
+        # api endpoint had relative protocol
+        # https://tools.ietf.org/html/rfc3986#section-5.2
+        provider_endpoint = uri.merge provider_endpoint
         provider_endpoint.query = nil
         provider_endpoint = provider_endpoint.to_s
       rescue URI::Error


### PR DESCRIPTION
If some service provides discoverable oembed link with relative protocol ("//example.com/oembed"), the url will be invalid and the request will crash

Example:
```
<link rel="alternate" type="application/json+oembed" href="//www.playbuzz.com/api/oembed/?url=https://www.playbuzz.com/qzeyrr10/plan-a-vacation-and-well-tell-you-what-job-you-should-have&amp;format=json">
```

This can be fixed by merging the request url with discovered api endpoint. Example:

```
irb(main):004:0> req = URI.parse('http://example.com/resource/123')
=> #<URI::HTTP http://example.com/resource/123>
irb(main):005:0> endpoint = URI.parse('//example.com/api/oembed')
=> #<URI::Generic //example.com/api/oembed>
irb(main):006:0> req.merge endpoint
=> #<URI::HTTP http://example.com/api/oembed>
```