### PR TITLE
Fix built-in YouTube provider to respond better given a private video

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,7 @@
 
 == Unreleased (0.14.1)
 
+* Fix the YouTube provider when given a private video; Issue #79 (Sebastian Schulze)
 
 == 0.14.0 - 5 November 2020
 

--- a/lib/oembed/providers.rb
+++ b/lib/oembed/providers.rb
@@ -157,7 +157,7 @@ module OEmbed
     #     OEmbed::Providers::Youtube.endpoint += "?iframe=0"
     # * To require https embed code
     #     OEmbed::Providers::Youtube.endpoint += "?scheme=https"
-    Youtube = OEmbed::Provider.new("https://www.youtube.com/oembed?scheme=https")
+    Youtube = OEmbed::Provider.new("https://www.youtube.com/oembed/?scheme=https")
     Youtube << "http://*.youtube.com/*"
     Youtube << "https://*.youtube.com/*"
     Youtube << "http://*.youtu.be/*"

--- a/spec/cassettes/OEmbed_Providers_Youtube.yml
+++ b/spec/cassettes/OEmbed_Providers_Youtube.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://www.youtube.com/watch?v=pO5L6vXtxsI
+    uri: https://www.youtube.com/oembed/?format=json&scheme=https&url=https://www.youtube.com/watch?v=pO5L6vXtxsI
     body:
       encoding: US-ASCII
       string: ''
@@ -18,42 +18,45 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
-      Vary:
-      - Origin,Accept-Encoding
-      - Referer
-      - X-Origin
-      Date:
-      - Mon, 28 Dec 2020 15:30:59 GMT
-      Server:
-      - scaffolding on HTTPServer2
-      Cache-Control:
-      - private
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
+      P3p:
+      - CP="This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl=en
+        for more info."
+      Expires:
+      - Tue, 27 Apr 1971 19:44:06 GMT
       X-Content-Type-Options:
       - nosniff
+      Date:
+      - Mon, 28 Dec 2020 15:32:04 GMT
+      Server:
+      - YouTube Frontend Proxy
+      X-Xss-Protection:
+      - '0'
       Alt-Svc:
       - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
         ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
       Accept-Ranges:
       - none
+      Vary:
+      - Accept-Encoding
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
-        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
-        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":270,"width":480,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022480\u0022 height=\u0022270\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
         frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
-  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+  recorded_at: Mon, 28 Dec 2020 15:32:04 GMT
 - request:
     method: get
-    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=http://www.youtube.com/watch?v=pO5L6vXtxsI
+    uri: https://www.youtube.com/oembed/?format=json&scheme=https&url=http://www.youtube.com/watch?v=pO5L6vXtxsI
     body:
       encoding: US-ASCII
       string: ''
@@ -69,42 +72,45 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      P3p:
+      - CP="This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl=en
+        for more info."
+      Cache-Control:
+      - no-cache
       Content-Type:
       - application/json
-      Vary:
-      - Origin,Accept-Encoding
-      - Referer
-      - X-Origin
-      Date:
-      - Mon, 28 Dec 2020 15:30:59 GMT
-      Server:
-      - scaffolding on HTTPServer2
-      Cache-Control:
-      - private
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000
+      Expires:
+      - Tue, 27 Apr 1971 19:44:06 GMT
       X-Content-Type-Options:
       - nosniff
+      Date:
+      - Mon, 28 Dec 2020 15:32:04 GMT
+      Server:
+      - YouTube Frontend Proxy
+      X-Xss-Protection:
+      - '0'
       Alt-Svc:
       - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
         ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
       Accept-Ranges:
       - none
+      Vary:
+      - Accept-Encoding
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
-        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
-        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":270,"width":480,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022480\u0022 height=\u0022270\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
         frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
-  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+  recorded_at: Mon, 28 Dec 2020 15:32:04 GMT
 - request:
     method: get
-    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://youtu.be/pO5L6vXtxsI
+    uri: https://www.youtube.com/oembed/?format=json&scheme=https&url=https://youtu.be/pO5L6vXtxsI
     body:
       encoding: US-ASCII
       string: ''
@@ -120,42 +126,45 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Expires:
+      - Tue, 27 Apr 1971 19:44:06 GMT
+      P3p:
+      - CP="This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl=en
+        for more info."
       Content-Type:
       - application/json
-      Vary:
-      - Origin,Accept-Encoding
-      - Referer
-      - X-Origin
-      Date:
-      - Mon, 28 Dec 2020 15:30:59 GMT
-      Server:
-      - scaffolding on HTTPServer2
       Cache-Control:
-      - private
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
+      - no-cache
       X-Content-Type-Options:
       - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 28 Dec 2020 15:32:04 GMT
+      Server:
+      - YouTube Frontend Proxy
+      X-Xss-Protection:
+      - '0'
       Alt-Svc:
       - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
         ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
       Accept-Ranges:
       - none
+      Vary:
+      - Accept-Encoding
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
-        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
-        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":270,"width":480,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022480\u0022 height=\u0022270\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
         frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
         encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
-  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+  recorded_at: Mon, 28 Dec 2020 15:32:04 GMT
 - request:
     method: get
-    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://youtu.be/NHriYTkvd0g
+    uri: https://www.youtube.com/oembed/?format=json&scheme=https&url=https://youtu.be/NHriYTkvd0g
     body:
       encoding: US-ASCII
       string: ''
@@ -168,34 +177,35 @@ http_interactions:
       - Mozilla/5.0 (compatible; ruby-oembed/0.14.0)
   response:
     status:
-      code: 200
-      message: OK
+      code: 403
+      message: Forbidden
     headers:
-      Content-Type:
-      - text/html
-      Vary:
-      - Origin
-      - Referer
-      - X-Origin
-      Date:
-      - Mon, 28 Dec 2020 15:30:59 GMT
-      Server:
-      - scaffolding on HTTPServer2
-      Cache-Control:
-      - private
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Length:
+      - '9'
       X-Content-Type-Options:
       - nosniff
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      P3p:
+      - CP="This is not a P3P policy! See http://support.google.com/accounts/answer/151657?hl=en
+        for more info."
+      Expires:
+      - Tue, 27 Apr 1971 19:44:06 GMT
+      Date:
+      - Mon, 28 Dec 2020 15:32:04 GMT
+      Server:
+      - YouTube Frontend Proxy
+      X-Xss-Protection:
+      - '0'
       Alt-Svc:
       - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
         ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
-      Transfer-Encoding:
-      - chunked
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: Forbidden
-  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+  recorded_at: Mon, 28 Dec 2020 15:32:04 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/OEmbed_Providers_Youtube.yml
+++ b/spec/cassettes/OEmbed_Providers_Youtube.yml
@@ -1,0 +1,201 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://www.youtube.com/watch?v=pO5L6vXtxsI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.14.0)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin,Accept-Encoding
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 28 Dec 2020 15:30:59 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+- request:
+    method: get
+    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=http://www.youtube.com/watch?v=pO5L6vXtxsI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.14.0)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin,Accept-Encoding
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 28 Dec 2020 15:30:59 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+- request:
+    method: get
+    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://youtu.be/pO5L6vXtxsI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.14.0)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Vary:
+      - Origin,Accept-Encoding
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 28 Dec 2020 15:30:59 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"title":"CKEditor 4.5 - Embedding Media Resources with oEmbed","author_name":"CKEditor
+        Ecosystem","author_url":"https://www.youtube.com/c/CKEditor","type":"video","height":113,"width":200,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/pO5L6vXtxsI/hqdefault.jpg","html":"\u003ciframe
+        width=\u0022200\u0022 height=\u0022113\u0022 src=\u0022https://www.youtube.com/embed/pO5L6vXtxsI?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+- request:
+    method: get
+    uri: https://www.youtube.com/oembed?format=json&scheme=https&url=https://youtu.be/NHriYTkvd0g
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.14.0)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/html
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 28 Dec 2020 15:30:59 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: Forbidden
+  recorded_at: Mon, 28 Dec 2020 15:30:59 GMT
+recorded_with: VCR 6.0.0

--- a/spec/providers/youtube_spec.rb
+++ b/spec/providers/youtube_spec.rb
@@ -1,0 +1,42 @@
+require File.join(File.dirname(__FILE__), '../spec_helper')
+
+describe 'OEmbed::Providers::Youtube' do
+  before(:all) do
+    VCR.insert_cassette('OEmbed_Providers_Youtube')
+  end
+  after(:all) do
+    VCR.eject_cassette
+  end
+
+  include OEmbedSpecHelper
+
+  let(:provider_class) { OEmbed::Providers::Youtube }
+
+  expected_valid_urls = %w(
+    https://www.youtube.com/watch?v=pO5L6vXtxsI
+    http://www.youtube.com/watch?v=pO5L6vXtxsI
+    https://youtu.be/pO5L6vXtxsI
+  )
+  expected_invalid_urls = [
+    # Unrecognized hostname
+    'https://www.youtube.co.uk/watch?v=pO5L6vXtxsI',
+  ]
+
+  it_should_behave_like(
+    "an OEmbed::Providers instance",
+    expected_valid_urls,
+    expected_invalid_urls
+  )
+
+  describe ".get" do
+    context 'given the URL of a private video' do
+      let(:invalid_url) { 'https://youtu.be/NHriYTkvd0g' }
+
+      it "should throw an UnknownResponse error" do
+        expect {
+          provider_class.get(invalid_url)
+        }.to raise_error(OEmbed::UnknownResponse, /403/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is intended to fix Issue #79 where YouTube's servers, confusingly, return a "200 OK" response for private videos rather than a "403 Forbidden" response.

With this PR in place, the built-in `OEmbed::Providers::Youtube` provider will throw the following error when given the URL of a private YouTube video: `OEmbed::UnknownResponse (Got unknown response (403) from server)`

* [x] Commit tests that fail for this case
* [x] Fix built-in `OEmbed::Providers::Youtube` provider
* [ ] Release a fix version of the gem