### PR TITLE
Reduce gem size

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -9,6 +9,7 @@
 * Add support for Instgram Reels URLs to the built-in OEmbed::Providers::Instagram.
 * Support focused rspec tests for local development (e.g. "fcontext" or "fit")
 * Fix a few typos in documentation & tests; Pull #76 (Inge Jørgensen)
+* Reduce gem size by removing test files.
 
 == 0.14.1 - 28 December 2020
 

--- a/ruby-oembed.gemspec
+++ b/ruby-oembed.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
 
   s.files = `git ls-files`.split("\n")
-  s.test_files = s.files.grep(%r{^(test|spec|features,integration_test)/})
 
   s.rdoc_options = ["--main", "README.rdoc", "--title", "ruby-oembed-#{OEmbed::Version}", "--inline-source", "--exclude", "tasks", "CHANGELOG.rdoc"]
   s.extra_rdoc_files = s.files.grep(%r{\.rdoc$}) + %w{LICENSE}

--- a/ruby-oembed.gemspec
+++ b/ruby-oembed.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ruby-oembed/ruby-oembed"
   s.licenses = ["MIT"]
 
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files`.split("\n").reject { |f| f.start_with?('spec/') || f.start_with?('integration_test/') }
 
   s.rdoc_options = ["--main", "README.rdoc", "--title", "ruby-oembed-#{OEmbed::Version}", "--inline-source", "--exclude", "tasks", "CHANGELOG.rdoc"]
   s.extra_rdoc_files = s.files.grep(%r{\.rdoc$}) + %w{LICENSE}


### PR DESCRIPTION
I was doing cleanup and noticed ruby-oembed gem was ~18MB, mostly because of `spec/cassettes/OEmbed_ProviderDiscovery.yml`.