### PR TITLE
Switch to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 bundler_args: --without guard
 cache: bundler
 rvm:
-  - 2.4.1
-  - 2.6.5
+  - 2.6.9
+  - 3.1.0
 env:
   global:
     - RUN_ALL_TESTS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ bundler_args: --without guard
 cache: bundler
 rvm:
   - 2.6.9
-  - 3.1.0
+  - 3.0.3
 env:
   global:
     - RUN_ALL_TESTS=true

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ The following, optional, backends are currently supported:
 
 # Lend a Hand
 
-**Note:** Work is under way on a v1.0 of ruby-oembed. If you'd like to contribute, take a look at [the rubocop branch!](https://github.com/ruby-oembed/ruby-oembed/tree/rubocop)
-
 Code for the ruby-oembed library is [hosted on GitHub](https://github.com/ruby-oembed/ruby-oembed).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ruby-oembed
 
 [![Gem](https://img.shields.io/gem/v/ruby-oembed.svg)](https://rubygems.org/gems/ruby-oembed)
-[![Travis branch](https://img.shields.io/travis/ruby-oembed/ruby-oembed/master.svg)](https://travis-ci.org/ruby-oembed/ruby-oembed/branches)
+[![Travis CI](https://img.shields.io/travis/com/ruby-oembed/ruby-oembed.svg)](https://app.travis-ci.com/github/ruby-oembed/ruby-oembed)
 [![Code Climate](https://img.shields.io/codeclimate/maintainability/ruby-oembed/ruby-oembed.svg)](https://codeclimate.com/github/ruby-oembed/ruby-oembed)
 [![Coveralls](https://coveralls.io/repos/github/ruby-oembed/ruby-oembed/badge.svg?branch=coveralls)](https://coveralls.io/github/ruby-oembed/ruby-oembed?branch=coveralls)
-![Maintenance](https://img.shields.io/maintenance/yes/2020.svg)
+![Maintenance](https://img.shields.io/maintenance/yes/2022.svg)
 
 
 An oEmbed consumer library written in Ruby, letting you easily get embeddable HTML representations of supported web pages, based on their URLs. See [oembed.com](http://oembed.com) for more about the protocol.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you encounter any bug, feel free to [create an Issue](https://github.com/ruby
 
 We gladly accept pull requests! Just [fork](http://help.github.com/forking/) the library and commit your changes along with relevant tests. Once you're happy with the changes, [send a pull request](http://help.github.com/pull-requests/).
 
-We do our best to [keep our tests green](http://travis-ci.org/ruby-oembed/ruby-oembed)
+We do our best to [keep our tests green](https://app.travis-ci.com/github/ruby-oembed/ruby-oembed)
 
 # Contributors
 


### PR DESCRIPTION
> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on. 

via https://travis-ci.org/github/ruby-oembed/ruby-oembed

* [x] Get tests working on travis-ci.org
* [x] Update all existing links to point to the correct, new travis-ci.com URLs.

Resolves #82 