### PR TITLE
Fix specs with ruby 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
 bundler_args: --without guard
 cache: bundler
 rvm:
-  - 2.6.9
-  - 3.0.3
+  - 2.6.10
+  - 3.1.2
 env:
   global:
     - RUN_ALL_TESTS=true

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -452,17 +452,17 @@ describe OEmbed::Provider do
 
     it "should send the provider's format if none is specified" do
       expect(@flickr).to receive(:raw).
-        with(example_url(:flickr), { :format => @default }).
+        with(example_url(:flickr), :format => @default).
         and_return(valid_response(@default))
       @flickr.get(example_url(:flickr))
 
       expect(@qik).to receive(:raw).
-        with(example_url(:qik), { :format=>:xml }).
+        with(example_url(:qik), :format=>:xml).
         and_return(valid_response(:xml))
       @qik.get(example_url(:qik))
 
       expect(@viddler).to receive(:raw).
-        with(example_url(:viddler), { :format=>:json }).
+        with(example_url(:viddler), :format=>:json).
         and_return(valid_response(:json))
       @viddler.get(example_url(:viddler))
     end
@@ -474,7 +474,7 @@ describe OEmbed::Provider do
         provider.send_with_query = 'non-blank-value'
 
         expect(provider).to receive(:http_get).
-          with(have_attributes(query: match(/send_with_query=non-blank-value/)), { :format => @default }).
+          with(have_attributes(query: match(/send_with_query=non-blank-value/)), :format => @default).
           and_return(valid_response(:json))
         provider.get(example_url(:fake))
       end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -452,17 +452,17 @@ describe OEmbed::Provider do
 
     it "should send the provider's format if none is specified" do
       expect(@flickr).to receive(:raw).
-        with(example_url(:flickr), :format => @default).
+        with(example_url(:flickr), { :format => @default }).
         and_return(valid_response(@default))
       @flickr.get(example_url(:flickr))
 
       expect(@qik).to receive(:raw).
-        with(example_url(:qik), :format=>:xml).
+        with(example_url(:qik), { :format=>:xml }).
         and_return(valid_response(:xml))
       @qik.get(example_url(:qik))
 
       expect(@viddler).to receive(:raw).
-        with(example_url(:viddler), :format=>:json).
+        with(example_url(:viddler), { :format=>:json }).
         and_return(valid_response(:json))
       @viddler.get(example_url(:viddler))
     end
@@ -474,7 +474,7 @@ describe OEmbed::Provider do
         provider.send_with_query = 'non-blank-value'
 
         expect(provider).to receive(:http_get).
-          with(have_attributes(query: match(/send_with_query=non-blank-value/)), :format => @default).
+          with(have_attributes(query: match(/send_with_query=non-blank-value/)), { :format => @default }).
           and_return(valid_response(:json))
         provider.get(example_url(:fake))
       end


### PR DESCRIPTION
With ruby 3.0 some specs fail because the expectation on arguments now
defaults to kwargs instead of a hash. Use explicit hashes in the
expectations to fix this. This change is backward compatible with
older ruby versions.