### PR TITLE
Update supported rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ before_install:
 bundler_args: --without guard
 cache: bundler
 rvm:
-  - 2.6.10
-  - 3.1.2
+  - 3.0.3
+  - 3.1.4
+  - 3.2.2
 env:
   global:
     - RUN_ALL_TESTS=true


### PR DESCRIPTION
# Problem 

Ruby 3.2 has recently been released and Ruby 2 has reached EOL. Rubies 3.0 and 3.1 still fall within recent maintenance.

https://www.ruby-lang.org/en/downloads/branches/

# Solution

Update supported Rubies in the Travis matrix.