### PR TITLE
Update RSpec configuration

### DIFF
--- a/spec/formatter/ducktype_backend_spec.rb
+++ b/spec/formatter/ducktype_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require 'spec_helper'
 
 class WorkingDuck
   # The WorkingDuck Class should work as a Backend

--- a/spec/formatter/json/jsongem_backend_spec.rb
+++ b/spec/formatter/json/jsongem_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 require 'json'
 
 describe "Setting JSON.backend = 'JSONGem'" do

--- a/spec/formatter/json/yaml_backend_spec.rb
+++ b/spec/formatter/json/yaml_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe "OEmbed::Formatter::JSON::Backends::Yaml" do
   include OEmbedSpecHelper

--- a/spec/formatter/xml/nokogiri_backend_spec.rb
+++ b/spec/formatter/xml/nokogiri_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe "OEmbed::Formatter::XML::Backends::Nokogiri" do
   include OEmbedSpecHelper

--- a/spec/formatter/xml/rexml_backend_spec.rb
+++ b/spec/formatter/xml/rexml_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe "OEmbed::Formatter::XML::Backends::REXML" do
   include OEmbedSpecHelper

--- a/spec/formatter/xml/xmlsimple_backend_spec.rb
+++ b/spec/formatter/xml/xmlsimple_backend_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require 'spec_helper'
 
 describe "OEmbed::Formatter::XML::Backends::XmlSimple" do
   include OEmbedSpecHelper

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 
 describe OEmbed::Formatter do
   include OEmbedSpecHelper

--- a/spec/provider_discovery_spec.rb
+++ b/spec/provider_discovery_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 require 'json'
 
 describe OEmbed::ProviderDiscovery do

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 
 describe OEmbed::Provider do
   before(:all) do

--- a/spec/providers/code_pen_spec.rb
+++ b/spec/providers/code_pen_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::CodePen' do
   use_custom_vcr_casette('OEmbed_Providers_CodePen')

--- a/spec/providers/facebook_post_spec.rb
+++ b/spec/providers/facebook_post_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::FacebookPost' do
   use_custom_vcr_casette('OEmbed_Providers_FacebookPost')

--- a/spec/providers/facebook_video_spec.rb
+++ b/spec/providers/facebook_video_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::FacebookVideo' do
   use_custom_vcr_casette('OEmbed_Providers_FacebookVideo')

--- a/spec/providers/instagram_spec.rb
+++ b/spec/providers/instagram_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::Instagram' do
   use_custom_vcr_casette('OEmbed_Providers_Instagram')

--- a/spec/providers/slideshare_spec.rb
+++ b/spec/providers/slideshare_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::Slideshare' do
   use_custom_vcr_casette('OEmbed_Providers_Slideshare')

--- a/spec/providers/tiktok_spec.rb
+++ b/spec/providers/tiktok_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::TikTok' do
   use_custom_vcr_casette('OEmbed_Providers_TikTok')
@@ -9,7 +9,7 @@ describe 'OEmbed::Providers::TikTok' do
   expected_valid_urls = [
     'https://www.tiktok.com/@shmemmmy/video/7005293332821822726',
     # video via iOS share card doesn't work
-    # 'https://vm.tiktok.com/TTPdMy6pFT/', 
+    # 'https://vm.tiktok.com/TTPdMy6pFT/',
   ]
   expected_invalid_urls = [
     'https://tiktok.com/@shmemmmy/video/7005293332821822726', # www is required

--- a/spec/providers/twitter_spec.rb
+++ b/spec/providers/twitter_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::Twitter' do
   use_custom_vcr_casette('OEmbed_Providers_Twitter')

--- a/spec/providers/youtube_spec.rb
+++ b/spec/providers/youtube_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../spec_helper')
+require 'spec_helper'
 
 describe 'OEmbed::Providers::Youtube' do
   use_custom_vcr_casette('OEmbed_Providers_Youtube')

--- a/spec/providers_spec.rb
+++ b/spec/providers_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 
 describe OEmbed::Providers do
   include OEmbedSpecHelper

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 
 def expected_helpers
   {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'rubygems'
+require 'bundler/setup'
 
 require 'vcr'
 VCR.configure do |c|
@@ -22,7 +22,7 @@ Coveralls.wear!
 
 require 'support/shared_examples_for_providers'
 
-require File.dirname(__FILE__) + '/../lib/oembed'
+require 'oembed'
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
# Problem

For local development:

- bundler/setup can be used to put Gemfile gems on the load path
- no need to require "rubygems" or set bundler in Gemfile
- RSpec can find "spec_helper.rb" without needing to specify `File.dirname(__FILE__)` ...

# Solution

Update spec_helper.rb, Gemfile, and spec require statements accordingly.
