### PR TITLE
Make specs pass regardless of execution order

### DIFF
--- a/lib/oembed/formatter/base.rb
+++ b/lib/oembed/formatter/base.rb
@@ -50,6 +50,11 @@ module OEmbed
         self.backend = old_backend
       end
 
+      def reset_backend
+        @backend = nil
+        remove_instance_variable(:@backend)
+      end
+
       private
 
       # Makes sure the given backend can correctly parse values using the decode

--- a/lib/oembed/formatter/json.rb
+++ b/lib/oembed/formatter/json.rb
@@ -15,11 +15,6 @@ module OEmbed
           @backend
         end
 
-        def reset_backend
-          @backend = nil
-          remove_instance_variable(:@backend)
-        end
-
         def set_default_backend
           DECODERS.find do |name|
             begin

--- a/lib/oembed/formatter/json.rb
+++ b/lib/oembed/formatter/json.rb
@@ -4,15 +4,20 @@ module OEmbed
     module JSON
       # A Array of all available backends, listed in order of preference.
       DECODERS = %w(ActiveSupportJSON JSONGem Yaml)
-      
+
       class << self
         include ::OEmbed::Formatter::Base
-        
+
         # Returns the current JSON backend.
         def backend
           set_default_backend unless defined?(@backend)
           raise OEmbed::FormatNotSupported, :json unless defined?(@backend)
           @backend
+        end
+
+        def reset_backend
+          @backend = nil
+          remove_instance_variable(:@backend)
         end
 
         def set_default_backend
@@ -26,21 +31,21 @@ module OEmbed
             end
           end
         end
-        
+
         private
-        
+
         def backend_path
           'json/backends'
         end
-        
+
         def test_value
           <<-JSON
 {"version":"1.0", "string":"test", "int":42,"html":"<i>Cool's</i>\\n the \\"word\\"\\u0021"}
           JSON
         end
-        
+
       end # self
-      
+
     end # JSON
   end
 end

--- a/spec/formatter/json/yaml_backend_spec.rb
+++ b/spec/formatter/json/yaml_backend_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 describe "OEmbed::Formatter::JSON::Backends::Yaml" do
   include OEmbedSpecHelper
 
-  before(:all) do
+  before(:each) do
     expect {
       OEmbed::Formatter::JSON.backend = 'Yaml'
     }.to_not raise_error

--- a/spec/formatter/xml/nokogiri_backend_spec.rb
+++ b/spec/formatter/xml/nokogiri_backend_spec.rb
@@ -9,7 +9,9 @@ describe "OEmbed::Formatter::XML::Backends::Nokogiri" do
     }.to raise_error(LoadError)
 
     require 'nokogiri'
+  end
 
+  before(:each) do
     expect {
       OEmbed::Formatter::XML.backend = 'Nokogiri'
     }.to_not raise_error

--- a/spec/formatter/xml/rexml_backend_spec.rb
+++ b/spec/formatter/xml/rexml_backend_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 describe "OEmbed::Formatter::XML::Backends::REXML" do
   include OEmbedSpecHelper
 
-  before(:all) do
+  before(:each) do
     expect {
       OEmbed::Formatter::XML.backend = 'REXML'
     }.to_not raise_error

--- a/spec/formatter/xml/xmlsimple_backend_spec.rb
+++ b/spec/formatter/xml/xmlsimple_backend_spec.rb
@@ -9,7 +9,9 @@ describe "OEmbed::Formatter::XML::Backends::XmlSimple" do
     }.to raise_error(LoadError)
 
     require 'xmlsimple'
+  end
 
+  before(:each) do
     expect {
       OEmbed::Formatter::XML.backend = 'XmlSimple'
     }.to_not raise_error

--- a/spec/provider_discovery_spec.rb
+++ b/spec/provider_discovery_spec.rb
@@ -3,11 +3,14 @@ require 'json'
 
 describe OEmbed::ProviderDiscovery do
   before(:all) do
-    OEmbed::Formatter::JSON.backend = 'JSONGem'
     VCR.insert_cassette('OEmbed_ProviderDiscovery')
   end
   after(:all) do
     VCR.eject_cassette
+  end
+
+  before(:each) do
+    OEmbed::Formatter::JSON.backend = 'JSONGem'
   end
 
   include OEmbedSpecHelper

--- a/spec/providers_spec.rb
+++ b/spec/providers_spec.rb
@@ -354,12 +354,12 @@ describe OEmbed::Providers do
         let(:embed_url) { 'https://www.facebook.com/exampleuser/posts/1234567890' }
 
         around(:each) do |each|
-          previous_value = ENV['OEMBED_FACEBOOK_TOKEN']
+          @previous_oembed_facebook_token = ENV['OEMBED_FACEBOOK_TOKEN']
           ENV['OEMBED_FACEBOOK_TOKEN'] = nil
           provider.access_token = nil
           each.run
-          ENV['OEMBED_FACEBOOK_TOKEN'] = previous_value
-          provider.access_token = previous_value
+          ENV['OEMBED_FACEBOOK_TOKEN'] = @previous_oembed_facebook_token
+          provider.access_token = @previous_oembed_facebook_token
           OEmbed::Providers.unregister_all
         end
 
@@ -380,6 +380,10 @@ describe OEmbed::Providers do
           end
 
           it { is_expected.to eql(provider) }
+
+          after do
+            OEmbed::Providers.register_all(access_tokens: { facebook: @previous_oembed_facebook_token })
+          end
         end
 
         context 'when access token is set ahead of time' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     OEmbed::Formatter::JSON.reset_backend
+    OEmbed::Formatter::XML.reset_backend
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec-status'
   config.filter_run_including :focus => true unless ENV['RUN_ALL_TESTS']
   config.run_all_when_everything_filtered = true
+
+  config.before(:each) do
+    OEmbed::Formatter::JSON.reset_backend
+  end
 end
 
 def use_custom_vcr_casette(casette_name)


### PR DESCRIPTION
# Problem

**Expected behavior:**

Tests pass when run in any order:

```sh
bundle exec rspec --order random
```

**Actual behavior:**

Tests can fail depending on what order they are run in. Here are examples on the default branch:

```sh
bundle exec rspec --order random --seed 7230  # fails
bundle exec rspec --order random --seed 31670 # fails

bundle ex rspec --order random --seed 53654  # passes
```

**Root causes:**

Using `--bisect`, I was able to determine a few separate issues:

- **Formatter configuration** Some tests assume a specific formatter backend for XML or JSON, The configured formatter for XML or JSON is a form of global state such that setting the value in one test can bleed across tests unless explicitly set/unset prior to running given tests. Setting the backend in a `before(:all)` config block does not guarantee the correct formatter.
- **Facebook access token configuration** The provider spec exercises the ability to set the Facebook access token via the `#register_all` method. The test does not reset the token for all Facebook provider classes causing specific provider specs to fail downstream when run after.

# Solution

- Adopt a strategy such that the JSON and XML formatter backends are reset prior to each test via a new method `Formatter::Base#reset_backed`. Tests that require a specific backend set the backend explicitly prior to exercising behavior. Tests that assume the default backend will work regardless of test order.
- Update the provider spec to reset the Facebook access token to the original value