### PR TITLE
Add Matterport provider

### DIFF
--- a/lib/oembed/providers/builtin_providers.rb
+++ b/lib/oembed/providers/builtin_providers.rb
@@ -6,6 +6,7 @@ require 'oembed/providers/facebook_post'
 require 'oembed/providers/facebook_video'
 require 'oembed/providers/instagram'
 require 'oembed/providers/tiktok'
+require 'oembed/providers/matterport'
 
 module OEmbed
   class Providers

--- a/lib/oembed/providers/builtin_providers.rb
+++ b/lib/oembed/providers/builtin_providers.rb
@@ -5,8 +5,8 @@
 require 'oembed/providers/facebook_post'
 require 'oembed/providers/facebook_video'
 require 'oembed/providers/instagram'
-require 'oembed/providers/tiktok'
 require 'oembed/providers/matterport'
+require 'oembed/providers/tiktok'
 
 module OEmbed
   class Providers

--- a/lib/oembed/providers/matterport.rb
+++ b/lib/oembed/providers/matterport.rb
@@ -1,0 +1,12 @@
+module OEmbed
+  class Providers
+    # Provider for my.matterport.com
+    Matterport = OEmbed::Provider.new(
+      "https://my.matterport.com/api/v1/models/oembed/",
+      format: :json
+    )
+    Matterport << "https://*.matterport.com/show/*"
+
+    add_official_provider(Matterport)
+  end
+end

--- a/spec/cassettes/OEmbed_Providers_Matterport.yml
+++ b/spec/cassettes/OEmbed_Providers_Matterport.yml
@@ -1,0 +1,221 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=FmDYedjofjo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Last-Modified:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Cf-Cache-Status:
+      - MISS
+      Content-Security-Policy:
+      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - private, no-store, must-revalidate
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 84e2bb909b9832c4-DTW
+    body:
+      encoding: ASCII-8BIT
+      string: '{"provider_url": "https://matterport.com", "version": "1.0", "thumbnail_width":
+        1920, "height": 480, "thumbnail_url": "https://my.matterport.com/api/v2/player/models/FmDYedjofjo/thumb/",
+        "thumbnail_height": 1080, "title": "Southern California Luxury Home", "width":
+        640, "html": "<iframe width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen
+        allow=\"xr-spatial-tracking\" src=\"https://my.matterport.com/show/?m=FmDYedjofjo\"
+        ></iframe>", "provider_name": "Matterport", "type": "rich"}'
+  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+- request:
+    method: get
+    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=iNvAlIdUrL
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '46'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - MISS
+      Content-Security-Policy:
+      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - private, no-store, must-revalidate
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 84e2bb91c8e532c4-DTW
+    body:
+      encoding: UTF-8
+      string: '{"message": "Not found.", "code": "not.found"}'
+  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+- request:
+    method: get
+    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=FmDYedjofjo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Last-Modified:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '0'
+      Content-Security-Policy:
+      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - private, no-store, must-revalidate
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 84e2bb92cda432c2-DTW
+    body:
+      encoding: ASCII-8BIT
+      string: '{"provider_url": "https://matterport.com", "version": "1.0", "thumbnail_width":
+        1920, "height": 480, "thumbnail_url": "https://my.matterport.com/api/v2/player/models/FmDYedjofjo/thumb/",
+        "thumbnail_height": 1080, "title": "Southern California Luxury Home", "width":
+        640, "html": "<iframe width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen
+        allow=\"xr-spatial-tracking\" src=\"https://my.matterport.com/show/?m=FmDYedjofjo\"
+        ></iframe>", "provider_name": "Matterport", "type": "rich"}'
+  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+- request:
+    method: get
+    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=iNvAlIdUrL
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 31 Jan 2024 14:44:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '46'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '0'
+      Content-Security-Policy:
+      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - private, no-store, must-revalidate
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 84e2bb938b1d6a25-DTW
+    body:
+      encoding: UTF-8
+      string: '{"message": "Not found.", "code": "not.found"}'
+  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+recorded_with: VCR 6.2.0

--- a/spec/cassettes/OEmbed_Providers_Matterport.yml
+++ b/spec/cassettes/OEmbed_Providers_Matterport.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 31 Jan 2024 14:44:26 GMT
+      - Thu, 01 Feb 2024 00:08:25 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -31,7 +31,7 @@ http_interactions:
       Last-Modified:
       - Wed, 31 Jan 2024 14:44:26 GMT
       Cf-Cache-Status:
-      - MISS
+      - EXPIRED
       Content-Security-Policy:
       - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
       Strict-Transport-Security:
@@ -47,7 +47,7 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 84e2bb909b9832c4-DTW
+      - 84e5f5b40a5c1436-PIT
     body:
       encoding: ASCII-8BIT
       string: '{"provider_url": "https://matterport.com", "version": "1.0", "thumbnail_width":
@@ -56,57 +56,7 @@ http_interactions:
         640, "html": "<iframe width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen
         allow=\"xr-spatial-tracking\" src=\"https://my.matterport.com/show/?m=FmDYedjofjo\"
         ></iframe>", "provider_name": "Matterport", "type": "rich"}'
-  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
-- request:
-    method: get
-    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=iNvAlIdUrL
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Wed, 31 Jan 2024 14:44:26 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '46'
-      Connection:
-      - keep-alive
-      Vary:
-      - Origin, Accept-Encoding
-      Cf-Cache-Status:
-      - MISS
-      Content-Security-Policy:
-      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Cache-Control:
-      - private, no-store, must-revalidate
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 84e2bb91c8e532c4-DTW
-    body:
-      encoding: UTF-8
-      string: '{"message": "Not found.", "code": "not.found"}'
-  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+  recorded_at: Thu, 01 Feb 2024 00:08:25 GMT
 - request:
     method: get
     uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=FmDYedjofjo
@@ -126,7 +76,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 31 Jan 2024 14:44:26 GMT
+      - Thu, 01 Feb 2024 00:08:25 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -156,7 +106,7 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 84e2bb92cda432c2-DTW
+      - 84e5f5b5e83a1435-PIT
     body:
       encoding: ASCII-8BIT
       string: '{"provider_url": "https://matterport.com", "version": "1.0", "thumbnail_width":
@@ -165,57 +115,5 @@ http_interactions:
         640, "html": "<iframe width=\"640\" height=\"480\" frameborder=\"0\" allowfullscreen
         allow=\"xr-spatial-tracking\" src=\"https://my.matterport.com/show/?m=FmDYedjofjo\"
         ></iframe>", "provider_name": "Matterport", "type": "rich"}'
-  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
-- request:
-    method: get
-    uri: https://my.matterport.com/api/v1/models/oembed/?format=json&url=https://my.matterport.com/show/?m=iNvAlIdUrL
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Mozilla/5.0 (compatible; ruby-oembed/0.16.1)
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Wed, 31 Jan 2024 14:44:26 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '46'
-      Connection:
-      - keep-alive
-      Vary:
-      - Origin, Accept-Encoding
-      Cf-Cache-Status:
-      - HIT
-      Age:
-      - '0'
-      Content-Security-Policy:
-      - frame-ancestors 'self' https://matterport.com https://*.matterport.com;
-      Strict-Transport-Security:
-      - max-age=31536000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Cache-Control:
-      - private, no-store, must-revalidate
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 84e2bb938b1d6a25-DTW
-    body:
-      encoding: UTF-8
-      string: '{"message": "Not found.", "code": "not.found"}'
-  recorded_at: Wed, 31 Jan 2024 14:44:26 GMT
+  recorded_at: Thu, 01 Feb 2024 00:08:25 GMT
 recorded_with: VCR 6.2.0

--- a/spec/providers/matterport_spec.rb
+++ b/spec/providers/matterport_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'OEmbed::Providers::Matterport' do
+  use_custom_vcr_casette('OEmbed_Providers_Matterport')
+  include OEmbedSpecHelper
+
+  let(:provider) { OEmbed::Providers::Matterport }
+
+  expected_valid_urls = %w(
+    https://my.matterport.com/show/?m=FmDYedjofjo
+  )
+  expected_invalid_urls = %w(
+    https://matterport.com/discover/space/7ffnfBNamei
+  )
+
+  describe 'behaving like an OEmbed::Provider instance' do
+    it_should_behave_like(
+      "an OEmbed::Providers instance",
+      expected_valid_urls,
+      expected_invalid_urls
+    )
+  end
+end


### PR DESCRIPTION
Supports rich interactive Matterport embeds without the need for relying on the fallback aggregators.

Matterport lets you create and embed 3D models of buildings and spaces, e.g. https://my.matterport.com/show/?m=FmDYedjofjo. Credit to @haeric for finding the [Matterport oEmbed provider URL](https://github.com/iamcal/oembed/pull/338/files).